### PR TITLE
Update workflow.ts

### DIFF
--- a/tools/workflow.ts
+++ b/tools/workflow.ts
@@ -43,7 +43,10 @@ if (import.meta.main) {
         },
         {
           name: "Install Deno",
-          uses: "denoland/setup-deno@v1",
+          uses: "denoland/setup-deno@v1.1.1",
+          with: {
+            "deno-version": "vx.x.x"
+          },
         },
         {
           name: "Install Node",


### PR DESCRIPTION
Use [the latest stable for any major](https://github.com/marketplace/actions/setup-deno#latest-stable-for-any-major):

```
- uses: denoland/setup-deno@v1
  with:
    deno-version: vx.x.x
```

## WRK test result

BUN (0.5.6):
```
wrk -t12 -c400 -d30s http://127.0.0.1:8000
Running 30s test @ http://127.0.0.1:8000
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.18ms  786.31us  46.76ms   83.21%
    Req/Sec     9.28k     4.39k   86.58k    65.65%
  3327113 requests in 30.10s, 409.31MB read
  Socket errors: connect 155, read 57, write 0, timeout 0
Requests/sec: 110544.20
Transfer/sec:     13.60MB
```

DENO (1.30.3):
```
wrk -t12 -c400 -d30s http://127.0.0.1:8000
Running 30s test @ http://127.0.0.1:8000
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.15ms  408.29us  24.60ms   90.61%
    Req/Sec     9.32k     3.91k   22.09k    56.53%
  3338009 requests in 30.02s, 410.66MB read
  Socket errors: connect 155, read 87, write 0, timeout 0
Requests/sec: 111200.45
Transfer/sec:     13.68MB
```

Deno is faster than bun, from the data above.

But in the `denosaurs-bench` results, Deno is always slower than Bun.

QUESTION:

Has deno been updated to the latest version?

Maybe you can update the github action to use the latest.

https://github.com/marketplace/actions/setup-deno